### PR TITLE
Feature/ignore upstream 5xx

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -11,9 +11,17 @@ local cjson_decode = require("cjson").decode
 local cjson_encode = require("cjson").encode
 local CACHE_HEADER = 'X-Kong-Cache-Status'
 
-local function cacheable_request(method, uri, conf)
+local status_code_bypass = { ngx.HTTP_BAD_GATEWAY, ngx.HTTP_SERVICE_UNAVAILABLE, ngx.HTTP_GATEWAY_TIMEOUT, ngx.HTTP_INTERNAL_SERVER_ERROR, ngx.HTTP_METHOD_NOT_IMPLEMENTED }
+
+local function cacheable_request(method, uri, conf, status_code)
   if method ~= "GET" then
     return false
+  end
+  
+  for _,v in ipairs(status_code_bypass) do
+    if v == status_code then
+      return false
+    end
   end
 
   for _,v in ipairs(conf.cache_policy.uris) do

--- a/handler.lua
+++ b/handler.lua
@@ -212,4 +212,6 @@ function CacheHandler:body_filter(conf)
   end
 end
 
+CacheHandler.PRIORITY = 10
+
 return CacheHandler

--- a/handler.lua
+++ b/handler.lua
@@ -70,6 +70,8 @@ local function json_decode(json)
     local status, res = pcall(cjson_decode, json)
     if status then
       return res
+    else 
+      ngx.log(ngx.ERR, "[response-cache] error decoding json: ", status, res)
     end
   end
 end
@@ -79,6 +81,8 @@ local function json_encode(table)
     local status, res = pcall(cjson_encode, table)
     if status then
       return res
+    else
+      ngx.log(ngx.ERR, "[response-cache] error encoding json: ", status, res)
     end
   end
 end


### PR DESCRIPTION
Hey @wshirey 👋 ,

I tested out your plugin with a json body but it seems to be giving json encoding errors. This patch fixes those issues as well as does the following:
- [x]  Skip caching when upstream gives back a 5xx
- [x] Assign priority to the plugin to execute after most plugins.

Let me know if any changes are needed.